### PR TITLE
feat: allow empty payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The arguments accepted as service data to this service is descibed bellow.
 | Name | Type | Requried | Supported options | Description |
 | ----------------- | ------ | -------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
 | `event_type` | string | yes | Any event type, ex `custom_event`| Event type |
-| `data` | string | yes |  | Any data to send with event |
+| `data` | string | no |  | Any data to send with event |
 
 #### Example
 This example uses the custom component ["button-card"](https://github.com/custom-cards/button-card/blob/master/README.md) 

--- a/custom_components/svc2evnt/__init__.py
+++ b/custom_components/svc2evnt/__init__.py
@@ -26,10 +26,7 @@ def setup(hass, config):
         except KeyError:
             raise ValueError("`event_type` argument was not supplied")
 
-        try:
-            payload = data["data"]
-        except KeyError:
-            raise ValueError("`data` argument was not supplied")
+        payload = data.get("data", {})
 
         hass.bus.fire(event_id, payload)
 


### PR DESCRIPTION
When triggering an event the data attribute may be left out. This will now result in a event with empty payload rather than an error.

Closes #3 